### PR TITLE
Drop all HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,11 @@
 language: php
 php:
   - nightly
-  - hhvm
   - '5.4'
   - '5.5'
   - '5.6'
   - '7.0'
   - '7.1'
-  - hhvm-3.3
-  - hhvm-3.6
-  - hhvm-3.9
-  - hhvm-3.12
-  - hhvm-3.15
-  - hhvm-3.18
-  - hhvm-nightly
+  - '7.2'
 
 script: php index.php


### PR DESCRIPTION
HHVM LTS 3.24 is the last version to support PHP 5 compatibility
third paragraph states "HHVM will not aim to target PHP7" and further down "We do not intend to be the runtime of choice for folks with pure PHP7 code." (just HACK)
https://hhvm.com/blog/2017/09/18/the-future-of-hhvm.html

add PHP 7.2